### PR TITLE
Rename Pharo 8 deprecated methods

### DIFF
--- a/Ghost-ObjectGhost/GHTMinimalGhost.trait.st
+++ b/Ghost-ObjectGhost/GHTMinimalGhost.trait.st
@@ -8,7 +8,7 @@ Method #isGhost is convinient method to easy check if object is ghost. It is imp
 "
 Trait {
 	#name : #GHTMinimalGhost,
-	#category : 'Ghost-ObjectGhost'
+	#category : #'Ghost-ObjectGhost'
 }
 
 { #category : #comparing }
@@ -22,12 +22,14 @@ GHTMinimalGhost >> == anObject [
 	self primitiveFailed
 ]
 
-{ #category : #'set implementation' }
-GHTMinimalGhost >> asSetElement [
+{ #category : #converting }
+GHTMinimalGhost >> asCollectionElement [
+	
 ]
 
-{ #category : #'set implementation' }
-GHTMinimalGhost >> enclosedSetElement [
+{ #category : #accessing }
+GHTMinimalGhost >> enclosedElement [
+	
 ]
 
 { #category : #accessing }

--- a/Ghost-ObjectGhost/GHTMinimalGhost.trait.st
+++ b/Ghost-ObjectGhost/GHTMinimalGhost.trait.st
@@ -27,9 +27,17 @@ GHTMinimalGhost >> asCollectionElement [
 	
 ]
 
+{ #category : #'set implementation' }
+GHTMinimalGhost >> asSetElement [
+]
+
 { #category : #accessing }
 GHTMinimalGhost >> enclosedElement [
 	
+]
+
+{ #category : #'set implementation' }
+GHTMinimalGhost >> enclosedSetElement [
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This should not be merged as is.

I noticed that in Pharo 8 two methods (`#asSetElement`, `#enclosedSetElement`) were removed. They were deprecated in Pharo 7, and `#asCollectionElement`, `#enclosedElement` are their replacements. This PR is based on v4.0.0, as I use it together with Seamless, but of course, it breaks Pharo <8 support. I am not sure what the package it. Maybe use class extensions?

The issue I observe together with Seamless is, that tries to send `#asCollectionElement` to a proxy from a server, which times out, as no server is running on the client.