### PR TITLE
add-project-class-to-baseline

### DIFF
--- a/BaselineOfGhost/BaselineOfGhost.class.st
+++ b/BaselineOfGhost/BaselineOfGhost.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BaselineOfGhost,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfGhost'
+	#category : #BaselineOfGhost
 }
 
 { #category : #baselines }
@@ -35,4 +35,11 @@ BaselineOfGhost >> baseline: spec [
 			group: 'ObjectCallHalt' with: #('Ghost-ObjectCallHalt-Tests' 'ObjectGhostTests' 'ClassGhostTests' 'ObjectMutationTests' 'GTSupport')
 		] 
 
+]
+
+{ #category : #accessing }
+BaselineOfGhost >> projectClass [
+	^ [ self class environment at: #MetacelloCypressBaselineProject ]
+		on: NotFound
+		do: [ super projectClass ]
 ]


### PR DESCRIPTION
Add project class to baseline.

This allows Metacello to better handle the updates of the project.