### PR TITLE
Implement NewTools support to inspect ghost objects

### DIFF
--- a/BaselineOfGhost/BaselineOfGhost.class.st
+++ b/BaselineOfGhost/BaselineOfGhost.class.st
@@ -15,24 +15,24 @@ BaselineOfGhost >> baseline: spec [
 			package: 'Ghost-ObjectGhost-Tests' with: [ spec requires: #('Ghost-ObjectGhost') ];
 			package: 'Ghost-ClassGhost-Tests' with: [ spec requires: #('Ghost-ClassGhost') ];
 			package: 'Ghost-ObjectMutation-Tests' with: [ spec requires: #('Ghost-ObjectMutation') ];
-			package: 'Ghost-GTSupport' with: [ spec requires: #('Ghost-ObjectGhost') ];
+			package: 'Ghost-NewToolsSupport' with: [ spec requires: #('Ghost-ObjectGhost') ];
 			package: 'Ghost-Learning' with: [ spec requires: #('Ghost-ObjectGhost') ];
 			package: 'Ghost-Learning-Tests' with: [ spec requires: #('Ghost-Learning')];
 			package: 'Ghost-ObjectCallHalt' with: [ spec requires: #('Ghost-ObjectMutation') ];
 			package: 'Ghost-ObjectCallHalt-Tests' with: [ spec requires: #('Ghost-ObjectCallHalt')].
 			
 		spec
- 			group: 'default' with: #( 'ObjectGhostTests' 'ClassGhostTests' 'ObjectMutationTests' 'GTSupport' 'LearningTests' );
+ 			group: 'default' with: #( 'ObjectGhostTests' 'ClassGhostTests' 'ObjectMutationTests' 'ToolsSupport' 'LearningTests' );
 			group: 'ObjectGhost' with: #('Ghost-ObjectGhost' );
 			group: 'ObjectGhostTests' with: #('Ghost-ObjectGhost-Tests' );
 			group: 'ClassGhost' with: #('Ghost-ClassGhost' );
 			group: 'ClassGhostTests' with: #('Ghost-ClassGhost-Tests' );
 			group: 'ObjectMutation' with: #('Ghost-ObjectMutation' );
 			group: 'ObjectMutationTests' with: #('Ghost-ObjectMutation-Tests' );
-			group: 'GTSupport' with: #('Ghost-GTSupport' );
+			group: 'ToolsSupport' with: #('Ghost-NewToolsSupport' );
 			group: 'Learning' with: #('Ghost-Learning' );
 			group: 'LearningTests' with: #('Ghost-Learning-Tests' );
-			group: 'ObjectCallHalt' with: #('Ghost-ObjectCallHalt-Tests' 'ObjectGhostTests' 'ClassGhostTests' 'ObjectMutationTests' 'GTSupport')
+			group: 'ObjectCallHalt' with: #('Ghost-ObjectCallHalt-Tests' 'ObjectGhostTests' 'ClassGhostTests' 'ObjectMutationTests' 'ToolsSupport')
 		] 
 
 ]

--- a/Ghost-Learning/GHLearning.class.st
+++ b/Ghost-Learning/GHLearning.class.st
@@ -22,7 +22,7 @@ Class {
 		'studiedMessages',
 		'teacher'
 	],
-	#category : 'Ghost-Learning'
+	#category : #'Ghost-Learning'
 }
 
 { #category : #'instance creation' }
@@ -50,8 +50,17 @@ GHLearning >> initialize [
 GHLearning >> installStudiedMessagesInto: aMetaMessagesClass [
 
 	studiedMessages do: [ :each |
-		(aMetaMessagesClass includes: each selector) ifFalse: [ 
+		(aMetaMessagesClass includesSelector: each selector) ifFalse: [ 
 			aMetaMessagesClass compile: each sourceCode classified: each category ]
+	]
+]
+
+{ #category : #operations }
+GHLearning >> installStudiedMessagesInto: aMetaMessagesClass asExtensionsOf: aPackageName [
+
+	studiedMessages do: [ :each |
+		(aMetaMessagesClass includesSelector: each selector) ifFalse: [ 
+			aMetaMessagesClass compile: each sourceCode classified: '*', aPackageName ]
 	]
 ]
 

--- a/Ghost-NewToolsSupport/GHGhostInspectionCollector.class.st
+++ b/Ghost-NewToolsSupport/GHGhostInspectionCollector.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #GHGhostInspectionCollector,
+	#superclass : #StInspectionCollector,
+	#category : #'Ghost-NewToolsSupport'
+}
+
+{ #category : #private }
+GHGhostInspectionCollector >> basicContextFromPragma: aPragma [
+	| context |	
+	context := GHGhostInspectionContext fromPragma: aPragma.
+	context inspectedObject: self inspectedObject.
+	^ context
+]

--- a/Ghost-NewToolsSupport/GHGhostInspectionContext.class.st
+++ b/Ghost-NewToolsSupport/GHGhostInspectionContext.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #GHGhostInspectionContext,
+	#superclass : #StInspectionContext,
+	#category : #'Ghost-NewToolsSupport'
+}
+
+{ #category : #'private - factory' }
+GHGhostInspectionContext >> basicNewInspectionPresenter [
+
+	| args |
+	args := self methodSelectorNeedsBuilder ifTrue: [{ self newPresenterBuilder }] ifFalse: [ #() ].
+	
+	^MirrorPrimitives  
+		withReceiver: self inspectedObject 
+		perform: self methodSelector 
+		withArguments: args
+]

--- a/Ghost-NewToolsSupport/GHGhostRawInspection.class.st
+++ b/Ghost-NewToolsSupport/GHGhostRawInspection.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #GHGhostRawInspection,
+	#superclass : #StRawInspection,
+	#category : #'Ghost-NewToolsSupport'
+}
+
+{ #category : #accessing }
+GHGhostRawInspection >> inspectorNodes [
+
+	^{ StInspectorSelfNode hostObject: self model }, 
+		((StNodeCollector for: self model) slotNodes)
+]
+
+{ #category : #stepping }
+GHGhostRawInspection >> step [
+	| rootNodes |
+
+	rootNodes := self inspectorNodes.
+	mementoNodes ifNil: [ 
+		mementoNodes := rootNodes collect: #mementoValue.
+		^ self ].
+	(rootNodes collect: #value) = mementoNodes ifTrue: [ ^ self ].
+
+	mementoNodes := rootNodes collect: #mementoValue.
+	attributeTable updateRootsKeepingSelection: rootNodes
+]

--- a/Ghost-NewToolsSupport/GHStandardMetaMessages.extension.st
+++ b/Ghost-NewToolsSupport/GHStandardMetaMessages.extension.st
@@ -1,0 +1,38 @@
+Extension { #name : #GHStandardMetaMessages }
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHStandardMetaMessages >> displayString [ 
+	^ghost ghostPrintString
+]
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHStandardMetaMessages >> displayStringLimitedTo: limit [
+	^self displayString
+]
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHStandardMetaMessages >> evaluatorInitialText: aStObjectContextPresenter [ 
+	^ '{1}' format: { aStObjectContextPresenter model codeSnippet } 
+]
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHStandardMetaMessages >> inspectionContexts [
+	"This is a utility method that collects all presentations for the current object.
+	By default, it simply looks for the #inspectorPresentationOrder:title: pragma.
+	The inspector can decice whether or not a presentation should be dispayed.
+	Subclasses might want to override it for more special behavior."
+
+	^ (GHGhostInspectionCollector on: ghost) collectInspectionContexts
+]
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHStandardMetaMessages >> inspectorNodes [
+	"Answer a list of attributes as nodes"
+	
+	^ (StNodeCollector for: ghost) slotNodes
+]
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHStandardMetaMessages >> stDisplayString [ 
+	^self displayString
+]

--- a/Ghost-NewToolsSupport/GHTMinimalGhost.extension.st
+++ b/Ghost-NewToolsSupport/GHTMinimalGhost.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #GHTMinimalGhost }
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHTMinimalGhost >> ghostInspectionRaw [
+	"This is the most basic presentation showing the state of the object"
+	<inspectorPresentationOrder: 900 title: 'Raw'>
+
+	^ GHGhostRawInspection on: self
+]
+
+{ #category : #'*Ghost-NewToolsSupport' }
+GHTMinimalGhost >> inspectorIcon [ 
+	^nil
+]

--- a/Ghost-NewToolsSupport/package.st
+++ b/Ghost-NewToolsSupport/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Ghost-NewToolsSupport' }


### PR DESCRIPTION
- NewTools support to inspect ghost objects
- Remove GTSupport from baseline

Current version with GT tooling is moved to pharo9 branch