### PR TITLE
Pharo 13 compatibility, dropped compatibility with Pharo 11-

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        smalltalk: [ Pharo64-12, Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
+        smalltalk: [ Pharo64-12, Pharo64-13 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2

--- a/Ghost-Learning-Tests/GHStudentTests.class.st
+++ b/Ghost-Learning-Tests/GHStudentTests.class.st
@@ -1,18 +1,19 @@
 Class {
-	#name : #GHStudentTests,
-	#superclass : #GHGhostTestCase,
+	#name : 'GHStudentTests',
+	#superclass : 'GHGhostTestCase',
 	#instVars : [
 		'teacher'
 	],
-	#category : 'Ghost-Learning-Tests'
+	#category : 'Ghost-Learning-Tests',
+	#package : 'Ghost-Learning-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 GHStudentTests >> ghostClass [
 	^GHStudent 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 GHStudentTests >> setUp [
 	super setUp.
 	
@@ -20,21 +21,21 @@ GHStudentTests >> setUp [
 	teacher := GHTeacherStub new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 GHStudentTests >> testInstallingStudiedMessages [
-	
+
 	| class |
 	class := GHMetaMessages newAnonymousSubclass.
 	ghost someMessage.
 	ghost printString.
 
-	[ghost learning installStudiedMessagesInto: class] on: AuthorNameRequest  do: [:err | err resume: nil].
-	
+	ghost learning installStudiedMessagesInto: class.
+
 	self assert: (class includesSelector: #someMessage).
 	self assert: (class includesSelector: #printString)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 GHStudentTests >> testLearningMessageFromObject [
 
 	| actual |
@@ -44,7 +45,7 @@ GHStudentTests >> testLearningMessageFromObject [
 	self assert: actual equals: 'a GHStudent'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 GHStudentTests >> testLearningMessageShouldAddItToStudiedMessages [
 	
 	| actual |
@@ -56,7 +57,7 @@ GHStudentTests >> testLearningMessageShouldAddItToStudiedMessages [
 	self assert: actual firstSender equals: thisContext
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 GHStudentTests >> testLearningMessageShouldExecuteIt [
 
 	| expected actual |

--- a/Ghost-Learning-Tests/GHTeacherStub.class.st
+++ b/Ghost-Learning-Tests/GHTeacherStub.class.st
@@ -2,12 +2,13 @@
 I am special class for tests which describe how GHLearningObject works
 "
 Class {
-	#name : #GHTeacherStub,
-	#superclass : #Object,
-	#category : 'Ghost-Learning-Tests'
+	#name : 'GHTeacherStub',
+	#superclass : 'Object',
+	#category : 'Ghost-Learning-Tests',
+	#package : 'Ghost-Learning-Tests'
 }
 
-{ #category : #'learning messages' }
+{ #category : 'learning messages' }
 GHTeacherStub >> someMessage [
 	^'some message should be studied'
 ]

--- a/Ghost-Learning-Tests/package.st
+++ b/Ghost-Learning-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Ghost-Learning-Tests' }
+Package { #name : 'Ghost-Learning-Tests' }

--- a/Ghost-Learning/GHLearnedMessage.class.st
+++ b/Ghost-Learning/GHLearnedMessage.class.st
@@ -13,16 +13,17 @@ Internal Representation and Key Implementation Points.
 	method:		<Method>
 "
 Class {
-	#name : #GHLearnedMessage,
-	#superclass : #Object,
+	#name : 'GHLearnedMessage',
+	#superclass : 'Object',
 	#instVars : [
 		'method',
 		'firstSender'
 	],
-	#category : 'Ghost-Learning'
+	#category : 'Ghost-Learning',
+	#package : 'Ghost-Learning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 GHLearnedMessage class >> from: senderContext method: aMethod [
 
 	^self new 
@@ -30,43 +31,50 @@ GHLearnedMessage class >> from: senderContext method: aMethod [
 		firstSender: senderContext 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearnedMessage >> category [
-	^method category
+
+	^ self protocolName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearnedMessage >> firstSender [
 	^ firstSender
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearnedMessage >> firstSender: anObject [
 	firstSender := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearnedMessage >> method [
 	^ method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearnedMessage >> method: anObject [
 	method := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 GHLearnedMessage >> printOn: aStream [
 
 	^method printOn: aStream 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
+GHLearnedMessage >> protocolName [
+
+	^ method protocolName
+]
+
+{ #category : 'accessing' }
 GHLearnedMessage >> selector [
 	^method selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearnedMessage >> sourceCode [
 	^method sourceCode
 ]

--- a/Ghost-Learning/GHLearning.class.st
+++ b/Ghost-Learning/GHLearning.class.st
@@ -15,30 +15,31 @@ Internal Representation and Key Implementation Points.
 	teacher:		<Class>
 "
 Class {
-	#name : #GHLearning,
-	#superclass : #GHGhostBehaviour,
+	#name : 'GHLearning',
+	#superclass : 'GHGhostBehaviour',
 	#instVars : [
 		'metaLevel',
 		'studiedMessages',
 		'teacher'
 	],
-	#category : #'Ghost-Learning'
+	#category : 'Ghost-Learning',
+	#package : 'Ghost-Learning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 GHLearning class >> by: aTeacherClass [
 
 	^self new 
 		teacher: aTeacherClass 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearning >> currentMetaLevel [
 
 	^metaLevel
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 GHLearning >> initialize [
 	super initialize.
 	
@@ -46,16 +47,17 @@ GHLearning >> initialize [
 	studiedMessages := Dictionary new.
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 GHLearning >> installStudiedMessagesInto: aMetaMessagesClass [
 
 	studiedMessages do: [ :each |
-		(aMetaMessagesClass includesSelector: each selector) ifFalse: [ 
-			aMetaMessagesClass compile: each sourceCode classified: each category ]
-	]
+			(aMetaMessagesClass includesSelector: each selector) ifFalse: [
+					aMetaMessagesClass
+						compile: each sourceCode
+						classified: each protocolName ] ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 GHLearning >> installStudiedMessagesInto: aMetaMessagesClass asExtensionsOf: aPackageName [
 
 	studiedMessages do: [ :each |
@@ -64,7 +66,7 @@ GHLearning >> installStudiedMessagesInto: aMetaMessagesClass asExtensionsOf: aPa
 	]
 ]
 
-{ #category : #'message interception' }
+{ #category : 'message interception' }
 GHLearning >> learnMessage: aMessage sentTo: aGhost [
 
 	| sender method learnedMessage |
@@ -79,7 +81,7 @@ GHLearning >> learnMessage: aMessage sentTo: aGhost [
 	^learnedMessage
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 GHLearning >> metaMessages: aMetaMessagesClass [
 
 	metaLevel := GHMetaLevel with: aMetaMessagesClass 
@@ -87,7 +89,7 @@ GHLearning >> metaMessages: aMetaMessagesClass [
 	
 ]
 
-{ #category : #'message interception' }
+{ #category : 'message interception' }
 GHLearning >> send: aMessage to: aGhost [
 
 	|  learnedMessage |
@@ -99,22 +101,22 @@ GHLearning >> send: aMessage to: aGhost [
 	^GHMetaMessages executeWith: aGhost andArguments: aMessage arguments method: learnedMessage method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearning >> studiedMessages [
 	^ studiedMessages
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearning >> studiedMessages: anObject [
 	studiedMessages := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearning >> teacher [
 	^ teacher
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHLearning >> teacher: anObject [
 	teacher := anObject
 ]

--- a/Ghost-Learning/GHStudent.class.st
+++ b/Ghost-Learning/GHStudent.class.st
@@ -7,41 +7,42 @@ Internal Representation and Key Implementation Points.
 	learning:		<Learning>
 "
 Class {
-	#name : #GHStudent,
-	#superclass : #GHObjectGhost,
+	#name : 'GHStudent',
+	#superclass : 'GHObjectGhost',
 	#instVars : [
 		'learning'
 	],
-	#category : 'Ghost-Learning'
+	#category : 'Ghost-Learning',
+	#package : 'Ghost-Learning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 GHStudent class >> new [
 	^self withTeacher: Object
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 GHStudent class >> withTeacher: aClass [
 	^self basicNew 
 		teacher: Object
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHStudent >> ghostBehaviour [
 	^learning
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHStudent >> learning [
 	^learning
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHStudent >> teacher [
 	^ learning teacher
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHStudent >> teacher: anObject [
 	learning := GHLearning by: anObject
 ]

--- a/Ghost-Learning/package.st
+++ b/Ghost-Learning/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Ghost-Learning' }
+Package { #name : 'Ghost-Learning' }

--- a/Ghost-NewToolsSupport/GHGhostInspectionCollector.class.st
+++ b/Ghost-NewToolsSupport/GHGhostInspectionCollector.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #GHGhostInspectionCollector,
-	#superclass : #StInspectionCollector,
-	#category : #'Ghost-NewToolsSupport'
+	#name : 'GHGhostInspectionCollector',
+	#superclass : 'StInspectionCollector',
+	#category : 'Ghost-NewToolsSupport',
+	#package : 'Ghost-NewToolsSupport'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 GHGhostInspectionCollector >> basicContextFromPragma: aPragma [
 	| context |	
 	context := GHGhostInspectionContext fromPragma: aPragma.

--- a/Ghost-NewToolsSupport/GHGhostInspectionContext.class.st
+++ b/Ghost-NewToolsSupport/GHGhostInspectionContext.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #GHGhostInspectionContext,
-	#superclass : #StInspectionContext,
-	#category : #'Ghost-NewToolsSupport'
+	#name : 'GHGhostInspectionContext',
+	#superclass : 'StInspectionContext',
+	#category : 'Ghost-NewToolsSupport',
+	#package : 'Ghost-NewToolsSupport'
 }
 
-{ #category : #'private - factory' }
+{ #category : 'private - factory' }
 GHGhostInspectionContext >> basicNewInspectionPresenter [
 
 	| args |

--- a/Ghost-NewToolsSupport/GHGhostRawInspection.class.st
+++ b/Ghost-NewToolsSupport/GHGhostRawInspection.class.st
@@ -1,17 +1,18 @@
 Class {
-	#name : #GHGhostRawInspection,
-	#superclass : #StRawInspection,
-	#category : #'Ghost-NewToolsSupport'
+	#name : 'GHGhostRawInspection',
+	#superclass : 'StRawInspectionPresenter',
+	#category : 'Ghost-NewToolsSupport',
+	#package : 'Ghost-NewToolsSupport'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GHGhostRawInspection >> inspectorNodes [
 
 	^{ StInspectorSelfNode hostObject: self model }, 
 		((StNodeCollector for: self model) slotNodes)
 ]
 
-{ #category : #stepping }
+{ #category : 'stepping' }
 GHGhostRawInspection >> step [
 	| rootNodes |
 

--- a/Ghost-NewToolsSupport/GHStandardMetaMessages.extension.st
+++ b/Ghost-NewToolsSupport/GHStandardMetaMessages.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #GHStandardMetaMessages }
+Extension { #name : 'GHStandardMetaMessages' }
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHStandardMetaMessages >> allInspectorNodes [
 	"Answer a list of attributes as nodes"
 
@@ -8,22 +8,22 @@ GHStandardMetaMessages >> allInspectorNodes [
 		self inspectorNodes
 ]
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHStandardMetaMessages >> displayString [ 
 	^ghost ghostPrintString
 ]
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHStandardMetaMessages >> displayStringLimitedTo: limit [
 	^self displayString
 ]
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHStandardMetaMessages >> evaluatorInitialText: aStObjectContextPresenter [ 
 	^ '{1}' format: { aStObjectContextPresenter model codeSnippet } 
 ]
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHStandardMetaMessages >> inspectionContexts [
 	"This is a utility method that collects all presentations for the current object.
 	By default, it simply looks for the #inspectorPresentationOrder:title: pragma.
@@ -33,14 +33,14 @@ GHStandardMetaMessages >> inspectionContexts [
 	^ (GHGhostInspectionCollector on: ghost) collectInspectionContexts
 ]
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHStandardMetaMessages >> inspectorNodes [
 	"Answer a list of attributes as nodes"
 	
 	^ (StNodeCollector for: ghost) slotNodes
 ]
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHStandardMetaMessages >> stDisplayString [ 
 	^self displayString
 ]

--- a/Ghost-NewToolsSupport/GHTMinimalGhost.extension.st
+++ b/Ghost-NewToolsSupport/GHTMinimalGhost.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #GHTMinimalGhost }
+Extension { #name : 'GHTMinimalGhost' }
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHTMinimalGhost >> ghostInspectionRaw [
 	"This is the most basic presentation showing the state of the object"
 	<inspectorPresentationOrder: 900 title: 'Raw'>
@@ -8,7 +8,7 @@ GHTMinimalGhost >> ghostInspectionRaw [
 	^ GHGhostRawInspection on: self
 ]
 
-{ #category : #'*Ghost-NewToolsSupport' }
+{ #category : '*Ghost-NewToolsSupport' }
 GHTMinimalGhost >> inspectorIcon [ 
 	^nil
 ]

--- a/Ghost-NewToolsSupport/package.st
+++ b/Ghost-NewToolsSupport/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Ghost-NewToolsSupport' }
+Package { #name : 'Ghost-NewToolsSupport' }

--- a/README.md
+++ b/README.md
@@ -8,29 +8,43 @@
 [![Pharo 9.0](https://img.shields.io/badge/Pharo-9.0-informational)](https://pharo.org)
 [![Pharo 10](https://img.shields.io/badge/Pharo-10-informational)](https://pharo.org)
 [![Pharo 11](https://img.shields.io/badge/Pharo-11-informational)](https://pharo.org)
-[![Pharo 11](https://img.shields.io/badge/Pharo-12-informational)](https://pharo.org)
+[![Pharo 12](https://img.shields.io/badge/Pharo-12-informational)](https://pharo.org)
+[![Pharo 13](https://img.shields.io/badge/Pharo-13-informational)](https://pharo.org)
 
 Ghost is framework to implement unnatural smalltalk objects like proxies or prototypes. It provides suitable infrastructure to implement message processing in special way
 
 ## Installation
-Use following script for Pharo version >= 10:
+The installation script (therefore version of Ghost) depends on Pharo version you are using it in.
+
+Pharo 13 (master branch):
 ```Smalltalk
 Metacello new
   baseline: 'Ghost';
-  repository: 'github://pharo-ide/Ghost';
+  repository: 'github://pharo-ide/Ghost:master';
   load
 ```
-To add dependency in your project baseline:
+
+Pharo 10-12 (v6.0.2 tag):
 ```Smalltalk
-spec
-    baseline: 'Ghost'
-    with: [ spec repository: 'github://pharo-ide/Ghost:v6.0.0' ]
+Metacello new
+  baseline: 'Ghost';
+  repository: 'github://pharo-ide/Ghost:v6.0.2';
+  load
 ```
-Notice that Pharo versions <= 9 were based on GTTools. In current Pharo it was removed and replaced by NewTools project. Ghost requires a dedicated tooling support to be able inspect Ghost objects. In order to use Ghost in old versions of Pharo load pharo9 branch instead of master:
+
+Pharo <= 9 (pharo9 tag):
 ```Smalltalk
 Metacello new
   baseline: 'Ghost';
   repository: 'github://pharo-ide/Ghost:pharo9';
   load
 ```
+
+To add dependency in your project baseline:
+```Smalltalk
+spec
+    baseline: 'Ghost'
+    with: [ spec repository: 'github://pharo-ide/Ghost:v6.0.2' ].
+```
+(replace the version in the URL depending on Pharo version as shown above with standalone scripts)
 


### PR DESCRIPTION
Conforming several changes made in Pharo 12 and 13, that caused Ghost not being able to load in Pharo 13. This PR aims to fix the compatibility with Pharo 13 and potentially with Pharo 14.

Fixes https://github.com/pharo-ide/Ghost/issues/16

This unfortunately drops compatibility with Pharo 11-. The main cause is a class StRawInspection being renamed to StRawInspectionPresenter in Pharo 12 as a deprecation via subclass, then completely in 13.

All the tests are green, including tests of Mocketry and a few projects using Mocketry (like OpenPonk).

Although there are no new features, this version should probably be released as v7.0.0 due to the incompatibility and to keep the 6.x version as a legacy version for older versions of Pharo.